### PR TITLE
removed fcntl from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 clint
-#fcntl
 qasync
 aiohttp
 pywin32

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,5 +1,4 @@
 clint
-fcntl
 qasync
 aiohttp
 #pywin32


### PR DESCRIPTION
Removed fcntl from requirements as it causes requirements install on linux to fail. fcntl is not hosted in the pypi repository and it comes included with python3 so it is not necessary to include.