### PR TITLE
Downgrade PyQt to 6.4 on macos + BUILD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,10 @@ glfw>=2.6.2
 
 # Interface stuff
 imgui>=2.0.0
-PyQt6-WebEngine>=6.5.0
-PyQt6>=6.5.0
+PyQt6-WebEngine>=6.5.0 ; sys_platform != "darwin"
+PyQt6>=6.5.0 ; sys_platform != "darwin"
+PyQt6-WebEngine>=6.4.0, <6.5.0 ; sys_platform == "darwin"
+PyQt6>=6.4.0, <6.5.0 ; sys_platform == "darwin"
 
 # Async goodness
 aiosqlite>=0.19.0


### PR DESCRIPTION
When I updated to 10.3-beta on my M1 Mac, I got a segfault when I tried to launch the app. After googling around for a while, I found a github issue on `PyInstaller` that described a similar issue. The problem had to do with an incompatibility between PyInstaller and PyQt 6.5 on macOS. Backing out to PyQt 6.4.x worked for the issue's author as a workaround, so I tried that here, and it seems to have worked. Now I can run 10.3-beta with no problem. Hopefully the code doesn't require PyQt 6.5 for anything!