### PR TITLE
Allow to load truncated images

### DIFF
--- a/modules/imagehelper.py
+++ b/modules/imagehelper.py
@@ -1,5 +1,5 @@
 # https://gist.github.com/Willy-JL/9c5116e5a11abd559c56f23aa1270de9
-from PIL import Image, ImageSequence, UnidentifiedImageError
+from PIL import Image, ImageFile, ImageSequence, UnidentifiedImageError
 import OpenGL.GL as gl
 import functools
 import pathlib
@@ -109,6 +109,7 @@ class ImageHelper:
             return
 
         try:
+            ImageFile.LOAD_TRUNCATED_IMAGES = True
             image = Image.open(self.resolved_path)
         except UnidentifiedImageError:
             self.invalid = True

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,6 +1,6 @@
 from PyQt6.QtWidgets import QSystemTrayIcon
 import OpenGL.GL as gl
-from PIL import Image
+from PIL import Image, ImageFile
 import concurrent
 import functools
 import asyncio
@@ -43,6 +43,7 @@ def map_range(in_value: float, in_start: float, in_end: float, out_start: float,
 
 def image_ext(data: bytes):
     try:
+        ImageFile.LOAD_TRUNCATED_IMAGES = True
         ext = str(Image.open(io.BytesIO(data)).format or "img").lower()
     except Exception:
         ext = "img"


### PR DESCRIPTION
FaceCrap described the issue in details [here](https://github.com/littleraisins/F95CheckerX/issues/6#issuecomment-1728124352).
TLDR; Some images are being falsely reported as invalid because Pillow by default does not allow to load corrupted images with mangled blocks, example threads with such images: [Naughty Lyanna](https://f95zone.to/threads/30364/) and [Maou-Sama](https://f95zone.to/threads/47559/).