### PR TITLE
Fixed integrated browser on Linux (issue #94)

### DIFF
--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -342,9 +342,18 @@ def open_webpage(url: str):
     async def _open_webpage(url: str):
         try:
             if set.browser.integrated:
-                proc = multiprocessing.Process(target=webview.open, args=(url,), kwargs=webview.kwargs() | dict(cookies=globals.cookies, size=(1269, 969)))
-                proc.start()
-                DaemonProcess(proc)
+                if globals.os is Os.Linux:
+                    await asyncio.create_subprocess_exec(
+                        *shlex.split(globals.start_cmd), "webview", "open", json.dumps((url,)),
+                        json.dumps(webview.kwargs() | dict(
+                            cookies=globals.cookies,
+                            size=(1269, 969),
+                        ))
+                    )
+                else:
+                    proc = multiprocessing.Process(target=webview.open, args=(url,), kwargs=webview.kwargs() | dict(cookies=globals.cookies, size=(1269, 969)))
+                    proc.start()
+                    DaemonProcess(proc)
             else:
                 await asyncio.create_subprocess_exec(
                     *args, url,


### PR DESCRIPTION
I've just copied invocation [method that login window uses](https://github.com/Willy-JL/F95Checker/blob/32110f018e654b9fddd35c5addba39280a683a98/modules/api.py#L312C20-L312C20). Looks like due to different threading implementation on Linux child process fails to acquire shared OpenGL context. Maybe there is a better way to fix it, but this should work just fine.

Here is some diagnostic information:

Initial error message: `g_main_context_push_thread_default: assertion 'acquired_context' failed`.

Integrated browser window fails to initialize/open only when:
- Running on Linux
- Application is frozen
- Using `multiprocessing.Process`


