### PR TITLE
Generate contrasting foreground colors for labels

### DIFF
--- a/modules/colors.py
+++ b/modules/colors.py
@@ -23,3 +23,11 @@ def rgba_0_1_to_hex(rgba: tuple[int, int, int, int | None]):
     else:
         a = "FF"
     return f"#{r}{g}{b}{a}"
+
+
+# credit: https://stackoverflow.com/a/1855903
+@functools.cache
+def foreground_color(bg: tuple[int, int, int, int | None]):
+    # calculcates 'perceptive luminance'
+    luma = 0.299 * bg[0] + 0.587 * bg[1] + 0.114 * bg[2]
+    return (0.0, 0.0, 0.0, 1.0) if luma > 0.5 else (1.0, 1.0, 1.0, 1.0)

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1034,6 +1034,7 @@ class MainGUI():
     def draw_label_widget(self, label: Label, short=False):
         quick_filter = globals.settings.quick_filters
         self.begin_framed_text(label.color, interaction=quick_filter)
+        imgui.push_style_color(imgui.COLOR_TEXT, *colors.foreground_color(label.color))
         if imgui.small_button(label.short_name if short else label.name) and quick_filter:
             flt = Filter(FilterMode.Label)
             flt.match = label
@@ -1044,6 +1045,7 @@ class MainGUI():
             self.draw_label_widget(label, short=False)
             imgui.pop_font()
             imgui.end_tooltip()
+        imgui.pop_style_color()
         self.end_framed_text(interaction=quick_filter)
 
     def draw_status_widget(self, status: Status):


### PR DESCRIPTION
The use of a single foreground color limits the range of colors available for label backgrounds, as some combinations are illegible. I tried applying the new `foreground_color` function to `begin_framed_text`, but it also impacts type widgets, which, as I understand, have been manually chosen to match forum colors. So, this PR only affects labels right now.
![image](https://github.com/Willy-JL/F95Checker/assets/153987701/4837951a-e4c6-4892-b9f2-f8f0ada50960)
![image](https://github.com/Willy-JL/F95Checker/assets/153987701/a4863791-4c9e-4691-aee7-920fda4593db)
