### PR TITLE
Option to disable showing app window after adding games from extension

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -167,6 +167,7 @@ async def connect():
             "display_mode":                f'INTEGER DEFAULT {DisplayMode.list}',
             "ext_icon_glow":               f'INTEGER DEFAULT {int(True)}',
             "ext_highlight_tags":          f'INTEGER DEFAULT {int(True)}',
+            "ext_background_add":          f'INTEGER DEFAULT {int(False)}',
             "fit_images":                  f'INTEGER DEFAULT {int(False)}',
             "filter_all_tabs":             f'INTEGER DEFAULT {int(False)}',
             "grid_columns":                f'INTEGER DEFAULT 3',

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -3886,6 +3886,12 @@ class MainGUI():
             )
             draw_settings_checkbox("ext_highlight_tags")
 
+            draw_settings_label(
+                "Add in the background:",
+                "Don't open F95Checker window after adding a game."
+            )
+            draw_settings_checkbox("ext_background_add")
+
             imgui.end_table()
             imgui.spacing()
 

--- a/modules/rpc_thread.py
+++ b/modules/rpc_thread.py
@@ -105,7 +105,8 @@ def start():
                         case "/games/add":
                             urls = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
                             if matches := utils.extract_thread_matches("\n".join(urls)):
-                                globals.gui.show()
+                                if not globals.settings.ext_background_add:
+                                    globals.gui.show()
                                 async def _add_game():
                                     await asyncio.sleep(0.1)
                                     await callbacks.add_games(*matches)

--- a/modules/structs.py
+++ b/modules/structs.py
@@ -628,6 +628,7 @@ class Settings:
     display_mode                : DisplayMode
     ext_icon_glow               : bool
     ext_highlight_tags          : bool
+    ext_background_add          : bool
     fit_images                  : bool
     filter_all_tabs             : bool
     grid_columns                : int


### PR DESCRIPTION
Necessary option, imo. Introduction of tabs eleviated the need to manage new games right away. I personally keep my "Default" empty and hidden most of the time, populating it with new games only.