### PR TITLE
Style overrides from toml file

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -304,6 +304,7 @@ class MainGUI():
         self.minimized = False
         self.filtering = False
         self.add_box_text = ""
+        self.new_styles = False
         self.prev_size = (0, 0)
         self.screen_pos = (0, 0)
         self.repeat_chars = False
@@ -719,6 +720,7 @@ class MainGUI():
                 globals.settings.style_border        = colors.hex_to_rgba_0_1(styles.get("border", DefaultStyle.border))
                 globals.settings.style_text          = colors.hex_to_rgba_0_1(styles.get("text", DefaultStyle.text))
                 globals.settings.style_text_dim      = colors.hex_to_rgba_0_1(styles.get("text_dim", DefaultStyle.text_dim))
+                self.new_styles = True
                 self.refresh_styles()
         except Exception:
             pass
@@ -849,6 +851,7 @@ class MainGUI():
                     # Redraw only when needed
                     draw = False
                     draw = draw or api.updating
+                    draw = draw or self.new_styles
                     draw = draw or imagehelper.redraw
                     draw = draw or self.recalculate_ids
                     draw = draw or size != self.prev_size
@@ -883,6 +886,7 @@ class MainGUI():
                         # Start drawing
                         prev_scaling = globals.settings.interface_scaling
                         imgui.new_frame()
+                        self.new_styles = False
                         imagehelper.redraw = False
 
                         # Imgui window is top left of display window, and has same size

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -12,6 +12,7 @@ import platform
 import builtins
 import asyncio
 import pathlib
+import tomllib
 import aiohttp
 import OpenGL
 import pickle
@@ -387,6 +388,7 @@ class MainGUI():
         self.refresh_fonts()
 
         self.load_filters()
+        self.load_styles_from_toml()
 
         # Show errors in threads
         def syncexcepthook(args: threading.ExceptHookArgs):
@@ -703,6 +705,23 @@ class MainGUI():
                 self.filters = pickle.load(file)
         except Exception:
             self.filters = []
+
+    def load_styles_from_toml(self):
+        if not (path := pathlib.Path(globals.data_path / 'styles.toml')).exists():
+            return
+        try:
+            with open(path, 'rb') as file:
+                styles = tomllib.load(file)
+                globals.settings.style_corner_radius = styles.get("corner_radius", DefaultStyle.corner_radius)
+                globals.settings.style_accent        = colors.hex_to_rgba_0_1(styles.get("accent", DefaultStyle.accent))
+                globals.settings.style_bg            = colors.hex_to_rgba_0_1(styles.get("bg", DefaultStyle.bg))
+                globals.settings.style_alt_bg        = colors.hex_to_rgba_0_1(styles.get("alt_bg", DefaultStyle.alt_bg))
+                globals.settings.style_border        = colors.hex_to_rgba_0_1(styles.get("border", DefaultStyle.border))
+                globals.settings.style_text          = colors.hex_to_rgba_0_1(styles.get("text", DefaultStyle.text))
+                globals.settings.style_text_dim      = colors.hex_to_rgba_0_1(styles.get("text_dim", DefaultStyle.text_dim))
+                self.refresh_styles()
+        except Exception:
+            pass
 
     def close(self, *_, **__):
         glfw.set_window_should_close(self.window, True)

--- a/modules/rpc_thread.py
+++ b/modules/rpc_thread.py
@@ -102,6 +102,9 @@ def start():
                             globals.gui.show()
                         case "/window/hide":
                             globals.gui.hide()
+                        case "/window/refresh_styles":
+                            globals.gui.load_styles_from_toml()
+                            globals.gui.refresh_styles()
                         case "/games/add":
                             urls = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
                             if matches := utils.extract_thread_matches("\n".join(urls)):


### PR DESCRIPTION
I'm using a Base16 generator to change my color scheme globally and rebuild my dotfiles with one command. This works great for command-line tools. For GTK/Qt, I use default dark themes. However, since f95checker is completely platform-independent, it's rather difficult to externally customize it. This PR exposes single `styles.toml` file, which, if it exists, will be used to override default styles; and RPC method which I can use as a hook, to refresh styles on the fly.

I know this is a pretty niche feature (I'm pretty sure I will be the only one who will use it, lol), but it will be invisible to the regular user, and I will greatly appreciate it if we can have it in the main branch so I don't have to apply patch for each new build.