### PR TITLE
Minor style fixes

### DIFF
--- a/modules/colors.py
+++ b/modules/colors.py
@@ -25,9 +25,9 @@ def rgba_0_1_to_hex(rgba: tuple[int, int, int, int | None]):
     return f"#{r}{g}{b}{a}"
 
 
-# credit: https://stackoverflow.com/a/1855903
 @functools.cache
 def foreground_color(bg: tuple[float, float, float, float | None]):
-    # calculcates 'perceptive luminance'
-    luma = 0.299 * bg[0] + 0.587 * bg[1] + 0.114 * bg[2]
-    return (0.04, 0.04, 0.04, 1.0) if luma > 0.5 else (1.0, 1.0, 1.0, 1.0)
+    gamma = 2.2
+    # https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+    luma = 0.2126 * pow(bg[0], gamma) + 0.7152 * pow(bg[1], gamma) + 0.0722 * pow(bg[2], gamma)
+    return (0.04, 0.04, 0.04, 1.0) if luma > pow(0.5, gamma) else (1.0, 1.0, 1.0, 1.0)

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1060,6 +1060,7 @@ class MainGUI():
     def draw_type_widget(self, type: Type, wide=True, align=False):
         quick_filter = globals.settings.quick_filters
         self.begin_framed_text(type.color, interaction=quick_filter)
+        imgui.push_style_color(imgui.COLOR_TEXT, 1.0, 1.0, 1.0, 1.0)
         if wide:
             x_padding = 4
             backup_y_padding = imgui.style.frame_padding.y
@@ -1076,6 +1077,7 @@ class MainGUI():
             flt = Filter(FilterMode.Type)
             flt.match = type
             self.filters.append(flt)
+        imgui.pop_style_color()
         self.end_framed_text(interaction=quick_filter)
 
     def draw_tag_widget(self, tag: Tag, quick_filter=True, change_highlight=True):


### PR DESCRIPTION
While playing around with various color themes, I noticed that the type widget's foreground is defined by the `text` style variable. This is problematic because the default `#ffffff` text already lacks contrast against most background colors defined in `Type`. I have adjusted the foreground color to always be `#ffffff`.

Also, `foreground_color` function was changed to follow proper W3 contrast spec.