### PR TITLE
Quickly reverse direction when smooth scrolling

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -857,6 +857,11 @@ class MainGUI():
                     # Scroll modifiers (must be before new_frame())
                     imgui.io.mouse_wheel *= globals.settings.scroll_amount
                     if globals.settings.scroll_smooth:
+
+                        if scroll_energy * imgui.io.mouse_wheel < 0: # fast check if signs are opposite
+                            # we want to immediately reverse rather than slowly decelerating.
+                            scroll_energy = 0.0
+
                         scroll_energy += imgui.io.mouse_wheel
                         if abs(scroll_energy) > 0.1:
                             scroll_now = scroll_energy * imgui.io.delta_time * globals.settings.scroll_smooth_speed


### PR DESCRIPTION
First affects everybody: if you're at the top or bottom of the page, it will keep imparting scroll energy that takes time to expend.  This makes the UI feel laggy and unresponsive if you've spun the scrollwheel to the top or bottom and want to start moving the other direction and it's still trying to scroll past the page.

Second affects people with enough games that they have pages of scroll.  If you've scrolled to the game you're looking for it will keep coasting on past, and attempting to scroll back up doesn't work until you've imparted enough energy in the opposite direction.  This can lead to overshoot.