### PR TITLE
Detect missing tags script

### DIFF
--- a/tags-diff.py
+++ b/tags-diff.py
@@ -1,6 +1,8 @@
+import os
+import sys
 import json
 
-from modules import async_thread, db
+from modules import async_thread, db, globals
 from modules.structs import Tag
 from modules.parser import html
 from modules import api
@@ -10,8 +12,16 @@ def main():
     async_thread.setup()
 
     with db.setup(), api.setup():
+        if xf_user := os.environ.get("XF_USER", None):
+            globals.cookies["xf_user"] = xf_user
+        if xf_tfa_trust := os.environ.get("XF_TFA_TRUST", None):
+            globals.cookies["xf_tfa_trust"] = xf_tfa_trust
         res = async_thread.wait(api.fetch("GET", f"{api.host}/sam/latest_alpha"))
-        txt = html(res).find("body").find("script").text  # type: ignore
+        try:
+            txt = html(res).find("body").find("script").text  # type: ignore
+        except Exception:
+            print("Failed to authenticate! Your auth cookies are stale or missing.")
+            sys.exit(1)
         txt = txt.replace("var latestUpdates =", "").replace(";", "").strip()
         obj = json.loads(txt)
         tags: dict[str, str] = obj["tags"]
@@ -25,8 +35,10 @@ def main():
         print("Some tags are missing:")
         for tag in missing:
             print(f"  - {tag}")
+        sys.exit(1)
     else:
         print("All tags are up-to-date!")
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tags-diff.py
+++ b/tags-diff.py
@@ -1,0 +1,33 @@
+import json
+
+from modules import async_thread, db
+from modules.structs import Tag
+from modules.parser import html
+from modules import api
+
+
+def main():
+    async_thread.setup()
+
+    with db.setup(), api.setup():
+        res = async_thread.wait(api.fetch("GET", f"{api.host}/sam/latest_alpha"))
+        txt = html(res).find("body").find("script").text  # type: ignore
+        txt = txt.replace("var latestUpdates =", "").replace(";", "").strip()
+        obj = json.loads(txt)
+        tags: dict[str, str] = obj["tags"]
+
+    missing = []
+    existing = [t.text for t in Tag]  # type: ignore
+    for tag in tags.values():
+        if tag not in existing:
+            missing.append(tag)
+    if missing:
+        print("Some tags are missing:")
+        for tag in missing:
+            print(f"  - {tag}")
+    else:
+        print("All tags are up-to-date!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Script detects missing tags by parsing the Latest Updates page using Selenium. It's not user-facing and is meant to be used like a pre-commit hook. As far as I know, this is the best way to parse all public tags at the moment.

![image](https://github.com/Willy-JL/F95Checker/assets/153987701/c28b640b-b2bf-4739-9824-a7bd3943912c)
