### PR TITLE
Gracefully handle unrecognized tags

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -608,7 +608,7 @@ async def full_check(game: Game, version: str):
             ret = parse(*args)
         if isinstance(ret, parser.ParserException):
             raise msgbox.Exc(*ret.args, **ret.kwargs)
-        (name, thread_version, developer, type, status, last_updated, score, votes, description, changelog, tags, image_url, downloads) = ret
+        (name, thread_version, developer, type, status, last_updated, score, votes, description, changelog, tags, unknown_tags, image_url, downloads) = ret
         if not version:
             if thread_version:
                 version = thread_version
@@ -645,6 +645,10 @@ async def full_check(game: Game, version: str):
         if not game.image_url == "custom" and not breaking_keep_old_image:
             fetch_image = fetch_image or (image_url != game.image_url)
 
+        unknown_tags_flag = game.unknown_tags_flag
+        if len(unknown_tags) > 0 and game.unknown_tags != unknown_tags:
+            unknown_tags_flag = True
+
         async def update_game():
             game.name = name
             game.version = version
@@ -663,6 +667,8 @@ async def full_check(game: Game, version: str):
             game.description = description
             game.changelog = changelog
             game.tags = tags
+            game.unknown_tags = unknown_tags
+            game.unknown_tags_flag = unknown_tags_flag
             game.image_url = image_url
             game.downloads = downloads
 

--- a/modules/db.py
+++ b/modules/db.py
@@ -257,6 +257,8 @@ async def connect():
             "description":                 f'TEXT    DEFAULT ""',
             "changelog":                   f'TEXT    DEFAULT ""',
             "tags":                        f'TEXT    DEFAULT "[]"',
+            "unknown_tags":                f'TEXT    DEFAULT "[]"',
+            "unknown_tags_flag":           f'INTEGER DEFAULT {int(False)}',
             "labels":                      f'TEXT    DEFAULT "[]"',
             "tab":                         f'INTEGER DEFAULT NULL',
             "notes":                       f'TEXT    DEFAULT ""',

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -8,6 +8,7 @@ import configparser
 import dataclasses
 import functools
 import threading
+import itertools
 import platform
 import builtins
 import asyncio
@@ -4380,6 +4381,26 @@ class MainGUI():
                             imgui.end_popup()
                     utils.push_popup(
                         utils.popup, "Export thread links",
+                        popup_content,
+                        buttons=True,
+                        closable=True,
+                        outside=False
+                    )
+                if imgui.button("Unknown tags", width=-offset):
+                    unknown_tags = builtins.type("_", (), dict(_="\n".join(builtins.set(itertools.chain.from_iterable(game.unknown_tags for game in globals.games.values())))))()
+                    def popup_content():
+                        imgui.input_text_multiline(
+                            "###export_unknown_tags",
+                            value=unknown_tags._,
+                            width=min(self.scaled(600), imgui.io.display_size.x * 0.6),
+                            height=imgui.io.display_size.y * 0.6,
+                            flags=imgui.INPUT_TEXT_READ_ONLY
+                        )
+                        if imgui.begin_popup_context_item("###export_unknown_tags_context"):
+                            utils.text_context(unknown_tags, "_", editable=False)
+                            imgui.end_popup()
+                    utils.push_popup(
+                        utils.popup, "Export unknown tags",
                         popup_content,
                         buttons=True,
                         closable=True,

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1166,16 +1166,11 @@ class MainGUI():
 
     def draw_game_update_icon(self, game: Game):
         quick_filter = globals.settings.quick_filters
-        if quick_filter:
-            imgui.begin_group()
+        with imgui.begin_group():
             pos = imgui.get_cursor_pos()
-        imgui.text_colored(icons.star_circle, 0.85, 0.85, 0.00)
-        if quick_filter:
+            imgui.text_colored(icons.star_circle, 0.85, 0.85, 0.00)
             imgui.set_cursor_pos(pos)
-            if imgui.invisible_button("", *imgui.get_item_rect_size()):
-                flt = Filter(FilterMode.Updated)
-                self.filters.append(flt)
-            imgui.end_group()
+            imgui.invisible_button("", *imgui.get_item_rect_size())
         if imgui.is_item_hovered():
             imgui.begin_tooltip()
             imgui.push_text_wrap_pos(min(imgui.get_font_size() * 35, imgui.io.display_size.x))
@@ -1187,29 +1182,55 @@ class MainGUI():
             imgui.same_line()
             imgui.text(game.version)
             imgui.text(
-                "Middle click to remove the update marker, alternatively\n"
-                "mark as installed to do the same."
+                "To remove this update marker:\n"
+                f"{icons.menu_right} Middle click\n"
+                f"{icons.menu_right} Alt + Left click\n"
+                f"{icons.menu_right} Mark game as installed"
             )
             imgui.pop_text_wrap_pos()
             imgui.end_tooltip()
         if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):
+            # Middle click - remove update marker
             game.updated = False
+        if imgui.is_item_clicked(imgui.MOUSE_BUTTON_LEFT):
+            if imgui.is_key_down(glfw.KEY_LEFT_ALT):
+                # Alt + left click - remove update marker
+                game.updated = False
+            elif quick_filter:
+                # Left click - trigger quick filter
+                flt = Filter(FilterMode.Updated)
+                self.filters.append(flt)
 
     def draw_game_unknown_tags_icon(self, game: Game):
-        imgui.text_colored(icons.progress_tag, 1.00, 0.65, 0.00)
+        with imgui.begin_group():
+            pos = imgui.get_cursor_pos()
+            imgui.text_colored(icons.progress_tag, 1.00, 0.65, 0.00)
+            imgui.set_cursor_pos(pos)
+            imgui.invisible_button("", *imgui.get_item_rect_size())
         if imgui.is_item_hovered():
             imgui.begin_tooltip()
             imgui.push_text_wrap_pos(min(imgui.get_font_size() * 35, imgui.io.display_size.x))
             imgui.text("This game has new tags that F95Checker failed to recognize:")
             for tag in game.unknown_tags:
                 imgui.text(f" - {tag}")
-            imgui.text("Consider reporting them on GitHub or in the forum thread.")
-            imgui.text("You can copy these tags using button in the Tags section.")
-            imgui.text("Middle click to dismiss this notice.")
+            imgui.text("To copy them:")
+            imgui.text(f"{icons.menu_right} Shift + Left click")
+            imgui.text(f"{icons.menu_right} Use Copy button in Tags section")
+            imgui.text("To remove this marker:")
+            imgui.text(f"{icons.menu_right} Middle click")
+            imgui.text(f"{icons.menu_right} Alt + Left click")
             imgui.pop_text_wrap_pos()
             imgui.end_tooltip()
         if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):
+            # Middle click - remove unknown tags marker
             game.unknown_tags_flag = False
+        if imgui.is_item_clicked(imgui.MOUSE_BUTTON_LEFT):
+            if imgui.is_key_down(glfw.KEY_LEFT_ALT):
+                # Alt + left click - remove unknown tags marker
+                game.unknown_tags_flag = False
+            elif imgui.is_key_down(glfw.KEY_LEFT_SHIFT):
+                # Shift + left click - copy tags to clipboard
+                callbacks.clipboard_copy(", ".join(game.unknown_tags))
 
     def draw_game_archive_icon(self, game: Game):
         quick_filter = globals.settings.quick_filters

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1195,6 +1195,22 @@ class MainGUI():
         if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):
             game.updated = False
 
+    def draw_game_unknown_tags_icon(self, game: Game):
+        imgui.text_colored(icons.progress_tag, 1.00, 0.65, 0.00)
+        if imgui.is_item_hovered():
+            imgui.begin_tooltip()
+            imgui.push_text_wrap_pos(min(imgui.get_font_size() * 35, imgui.io.display_size.x))
+            imgui.text("This game has new tags that F95Checker failed to recognize:")
+            for tag in game.unknown_tags:
+                imgui.text(f" - {tag}")
+            imgui.text("Consider reporting them on GitHub or in the forum thread.")
+            imgui.text("You can copy these tags using button in the Tags section.")
+            imgui.text("Middle click to dismiss this notice.")
+            imgui.pop_text_wrap_pos()
+            imgui.end_tooltip()
+        if imgui.is_item_clicked(imgui.MOUSE_BUTTON_MIDDLE):
+            game.unknown_tags_flag = False
+
     def draw_game_archive_icon(self, game: Game):
         quick_filter = globals.settings.quick_filters
         if quick_filter:
@@ -1951,6 +1967,9 @@ class MainGUI():
             if game.updated:
                 self.draw_game_update_icon(game)
                 imgui.same_line()
+            if game.unknown_tags_flag:
+                self.draw_game_unknown_tags_icon(game)
+                imgui.same_line()
             offset = imgui.calc_text_size("Version:").x + imgui.style.item_spacing.x
             utils.wrap_text(game.version, width=offset + imgui.get_content_region_available_width(), offset=offset)
 
@@ -2231,6 +2250,14 @@ class MainGUI():
                         self.draw_game_tags_widget(game)
                     else:
                         imgui.text_disabled("This game has no tags!")
+                    if utags := game.unknown_tags:
+                        imgui.spacing()
+                        if imgui.tree_node(f"Unknown tags ({len(utags)})"):
+                            if imgui.button(f"{icons.tag_multiple_outline} Copy"):
+                                callbacks.clipboard_copy(", ".join(utags))
+                            for tag in utags:
+                                imgui.text(f"- {tag}")
+                            imgui.tree_pop()
                     imgui.end_tab_item()
 
                 if imgui.begin_tab_item((
@@ -2972,6 +2999,9 @@ class MainGUI():
                             if game.updated:
                                 self.draw_game_update_icon(game)
                                 imgui.same_line()
+                            if game.unknown_tags_flag:
+                                self.draw_game_unknown_tags_icon(game)
+                                imgui.same_line()
                             self.draw_game_name_text(game)
                             if game.notes:
                                 imgui.same_line()
@@ -3249,6 +3279,10 @@ class MainGUI():
             cluster = True
         if game.updated:
             self.draw_game_update_icon(game)
+            imgui.same_line()
+            cluster = True
+        if game.unknown_tags_flag:
+            self.draw_game_unknown_tags_icon(game)
             imgui.same_line()
             cluster = True
         if game.notes:

--- a/modules/parser.py
+++ b/modules/parser.py
@@ -326,11 +326,15 @@ def thread(game_id: int, res: bytes, pipe: multiprocessing.Queue = None):
         changelog = changelog_regex if len(changelog_regex) > len(changelog_html) else changelog_html
 
         tags = []
+        unknown_tags = []
         if (taglist := head.find(is_class("js-tagList"))) is not None:
             for child in taglist.children:
                 if hasattr(child, "get") and "/tags/" in (tag := child.get("href", "")):
                     tag = tag.replace("/tags/", "").strip("/")
-                    tags.append(Tag[tag])
+                    if tag not in Tag._member_names_:
+                        unknown_tags.append(tag)
+                    else:
+                        tags.append(Tag[tag])
         tags = tuple(sorted(tags))
 
         elem = post.find(is_class("bbWrapper")).find(lambda elem: elem.name == "img" and "data-src" in elem.attrs)
@@ -354,7 +358,7 @@ def thread(game_id: int, res: bytes, pipe: multiprocessing.Queue = None):
         else:
             return e
 
-    ret = (name, thread_version, developer, type, status, last_updated, score, votes, description, changelog, tags, image_url, downloads)
+    ret = (name, thread_version, developer, type, status, last_updated, score, votes, description, changelog, tags, unknown_tags, image_url, downloads)
     if pipe:
         pipe.put_nowait(ret)
     else:

--- a/modules/structs.py
+++ b/modules/structs.py
@@ -756,6 +756,8 @@ class Game:
     description        : str
     changelog          : str
     tags               : tuple[Tag]
+    unknown_tags       : list[str]
+    unknown_tags_flag  : bool
     labels             : list[Label.get]
     tab                : Tab.get
     notes              : str
@@ -911,6 +913,8 @@ class Game:
             "description",
             "changelog",
             "tags",
+            "unknown_tags",
+            "unknown_tags_flag",
             "labels",
             "tab",
             "notes",


### PR DESCRIPTION
Since tags will remain manually managed in the foreseeable future, handling unrecognized tags without throwing errors and aborting parsing is a must-have feature, which is long overdue in my opinion. Currently, [users are forced to remove threads from the app](https://f95zone.to/threads/f95checker-willyjl.44173/post-13308483) because even archived threads require a full recheck if they are of type `Unchecked`.

![2024-03-27-100054_1920x1080_scrot](https://github.com/Willy-JL/F95Checker/assets/153987701/9a547851-f215-4d83-bcb1-23e3da0baa8d)

![image](https://github.com/Willy-JL/F95Checker/assets/153987701/68c94e20-3cc7-4b7c-9f79-cc2a9ef69ece)

