### PR TITLE
mark installed after adding executable

### DIFF
--- a/modules/structs.py
+++ b/modules/structs.py
@@ -929,6 +929,10 @@ class Game:
         from modules import async_thread, db
         async_thread.run(db.update_game(self, "executables"))
         self.validate_executables()
+        if self.installed != self.version:
+            self.add_timeline_event(TimelineEventType.GameInstalled, self.version)
+            self.installed = self.version
+            self.updated = False
 
     def remove_executable(self, executable: str):
         self.executables.remove(executable)


### PR DESCRIPTION
Saw a request in the thread to mark a game as installed after adding an executable if it wasn't yet marked.

Thought that was actually quite handy so did a quick edit and test.