### PR TITLE
Add macOS arm64 build

### DIFF
--- a/.github/workflow_data/release.py
+++ b/.github/workflow_data/release.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     ).json()
     print(f"release = {json.dumps(release, indent=4)}")
     body = "## ⬇️ Download\n"
-    for asset_type, asset_icon in [("Windows", "🪟"), ("Linux", "🐧"), ("MacOS", "🍎"), ("Source", "🐍")]:
+    for asset_type, asset_icon in [("Windows", "🪟"), ("Linux", "🐧"), ("macOS-x64", "🍎"), ("macOS-arm64", "🍎"), ("Source", "🐍")]:
         print(f"Adding {asset_type}")
         for asset in release["assets"]:
             if asset_type.lower() in asset["name"].lower():

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: "windows-2022",   python: "3.12.4", cx-freeze: "7.0.0", cx-logging: "v3.2.0", astcenc: "5.1.0", compressonator: "4.5.52" }
-          - { os: "ubuntu-22.04",   python: "3.12.4", cx-freeze: "7.0.0", cx-logging: ""      , astcenc: "5.1.0", compressonator: "4.5.52" }
-          - { os: "macos-15-intel", python: "3.12.4", cx-freeze: "7.0.0", cx-logging: ""      , astcenc: "5.1.0", compressonator: ""       }
+          - { os: "windows-2022",   python: "3.12.4", cx-freeze: "7.0.0", cx-logging: "v3.2.0", astcenc: "5.1.0", compressonator: "4.5.52", artifact: "Windows" }
+          - { os: "ubuntu-22.04",   python: "3.12.4", cx-freeze: "7.0.0", cx-logging: "",       astcenc: "5.1.0", compressonator: "4.5.52", artifact: "Linux" }
+          - { os: "macos-15-intel", python: "3.12.4", cx-freeze: "7.0.0", cx-logging: "",       astcenc: "5.1.0", compressonator: "",       artifact: "macOS-x64" }
+          - { os: "macos-15",       python: "3.12.4", cx-freeze: "7.0.0", cx-logging: "",       astcenc: "5.1.0", compressonator: "",       artifact: "macOS-arm64" }
     name: "${{ matrix.config.os }}"
     runs-on: "${{ matrix.config.os }}"
     if: "github.event_name != 'push' || contains(github.event.head_commit.message, '+ BUILD')"
@@ -150,14 +151,14 @@ jobs:
       - name: "Zip artifact"
         run: |
           cd ./dist/
-          7z a ../${{ github.event.repository.name }}-${{ runner.os }}.zip .
+          7z a ../${{ github.event.repository.name }}-${{ matrix.config.artifact }}.zip .
 
       - name: "Upload commit artifact"
         if: "github.event_name != 'release'"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "${{ github.event.repository.name }}-${{ runner.os }}-Artifact"
-          path: "./${{ github.event.repository.name }}-${{ runner.os }}.zip"
+          name: "${{ github.event.repository.name }}-${{ matrix.config.artifact }}-Artifact"
+          path: "./${{ github.event.repository.name }}-${{ matrix.config.artifact }}.zip"
           compression-level: 0
 
       - name: "Upload release artifact"
@@ -166,7 +167,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          files: "./${{ github.event.repository.name }}-${{ runner.os }}.zip"
+          files: "./${{ github.event.repository.name }}-${{ matrix.config.artifact }}.zip"
 
   source:
     name: "source"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Saves a lot of VRAM if completely disabled, no GIFs play and only first frame is loaded
   - Saves CPU/GPU usage by redrawing less if disabled when unfocused, but still uses same VRAM
 - Tabs can now be reordered by dragging (by @WillyJL)
+- macOS arm64 (Apple Silicon) binary builds (#258 by @rakleed)
 
 ### Updated:
 - New notification system with buttons and better platform support, option to include banner image in update notifs (#220 by @WillyJL)


### PR DESCRIPTION
Closes https://github.com/WillyJL/F95Checker/issues/257

I checked the compiled build for arm64, and it works correctly.

Here's how Claude Code explained why these changes will be enough:

<details><summary>Details</summary>

<html><head></head><body>
<p><strong>Dependency analysis and fixes</strong></p>
<p>Dependencies without ARM64 wheels on macOS:</p>

Package | Status | Resolution
-- | -- | --
imgui==2.0.0 | ❌ x86_64 only | pip automatically builds from source (sdist contains pre-generated C files, Cython not required)
zipfile-deflate64-macos==0.1.0 | ⚠️ universal2 for cp39 only | pip builds from source on Python 3.12 (same as on Intel)


<p>All other dependencies (<code>zstd</code>, <code>bencode2</code>, <code>pillow-avif-plugin</code>, <code>lxml</code>, <code>cx-Freeze</code>, etc.) already have native ARM64 or universal2 wheels.</p>
<p><strong>Changes made to <code>.github/workflows/build.yml</code>:</strong></p>
<ol>
<li>Added new runner <code>macos-15</code> (Apple Silicon / ARM64) to the build matrix</li>
<li>Added <code>artifact</code> field to each matrix entry for unique artifact names: <code>Windows</code>, <code>Linux</code>, <code>macOS</code>, <code>macOS-ARM64</code> — replacing the previous <code>runner.os</code> which produced the same name <code>macOS</code> for both macOS builds</li>
</ol>
<p><strong>Why this works:</strong></p>
<p>On the ARM64 runner (<code>macos-15</code>), pip won't find compatible wheels for <code>imgui==2.0.0</code> (x86_64 only) and will automatically fall back to building from sdist. The sdist already contains pre-generated C files, and Xcode Command Line Tools (pre-installed on GitHub runners) will compile them into a native ARM64 binary.</p>

</details>