### PR TITLE
Fix macOS .app bundle support for game launch

### DIFF
--- a/common/structs.py
+++ b/common/structs.py
@@ -1036,16 +1036,22 @@ class Game:
                     if base in exe.parents:
                         self.executables[i] = exe.relative_to(base).as_posix()
                         changed = True
-                    executables_valids.append(exe.is_file())
+                    executables_valids.append(exe.is_file() or (globals.os is Os.MacOS and exe.suffix == ".app" and exe.is_dir()))
                 else:
-                    executables_valids.append((base / exe).is_file())
+                    abs_exe = base / exe
+                    executables_valids.append(abs_exe.is_file() or (globals.os is Os.MacOS and abs_exe.suffix == ".app" and abs_exe.is_dir()))
             self.executables_valids = executables_valids
             if changed:
                 from external import async_thread
                 from modules import db
                 async_thread.run(db.update_game(self, "executables"))
         else:
-            self.executables_valids = [utils.is_uri(executable) or os.path.isfile(executable) for executable in self.executables]
+            def _exe_valid(executable):
+                if utils.is_uri(executable):
+                    return True
+                exe = pathlib.Path(executable)
+                return exe.is_file() or (globals.os is Os.MacOS and exe.suffix == ".app" and exe.is_dir())
+            self.executables_valids = [_exe_valid(e) for e in self.executables]
         self.executables_valid = all(self.executables_valids)
         if globals.gui:
             globals.gui.recalculate_ids = True

--- a/external/filepicker.py
+++ b/external/filepicker.py
@@ -105,7 +105,8 @@ class FilePicker:
                 items.sort(key=lambda item: item.name.lower())  # Sort alphabetically
                 items.sort(key=lambda item: item.is_dir(), reverse=True)  # Sort dirs first
                 for item in items:
-                    self.items.append((dir_icon if item.is_dir() else file_icon) + item.name)
+                    is_app_bundle = sys.platform.startswith("darwin") and item.is_dir() and item.suffix == ".app"
+                    self.items.append((file_icon if (not item.is_dir() or is_app_bundle) else dir_icon) + item.name)
             else:
                 self.items.append("No items match your filter!" if self.filter_box_text else "This folder is empty!")
         except Exception:

--- a/external/filepicker.py
+++ b/external/filepicker.py
@@ -106,7 +106,7 @@ class FilePicker:
                 items.sort(key=lambda item: item.is_dir(), reverse=True)  # Sort dirs first
                 for item in items:
                     is_app_bundle = sys.platform.startswith("darwin") and item.is_dir() and item.suffix == ".app"
-                    self.items.append((file_icon if (not item.is_dir() or is_app_bundle) else dir_icon) + item.name)
+                    self.items.append((dir_icon if (item.is_dir() and not is_app_bundle) else file_icon) + item.name)
             else:
                 self.items.append("No items match your filter!" if self.filter_box_text else "This folder is empty!")
         except Exception:

--- a/modules/callbacks.py
+++ b/modules/callbacks.py
@@ -178,6 +178,9 @@ async def _launch_exe(executable: str):
     exe = pathlib.Path(executable)
     if globals.settings.default_exe_dir.get(globals.os) and not exe.is_absolute():
         exe = pathlib.Path(globals.settings.default_exe_dir.get(globals.os)) / exe
+    if globals.os is Os.MacOS and exe.suffix == ".app" and exe.is_dir():
+        await default_open(str(exe))
+        return
     if not exe.is_file():
         raise FileNotFoundError()
 


### PR DESCRIPTION
Fixes #245

## Problem

On macOS, game applications are distributed as `.app` bundles which are
**directories** on the filesystem, not files. This caused three failures:

1. **File picker** — `.app` dirs appeared as folders; double-clicking
   navigated *into* them instead of selecting them as an executable
2. **Validation** — `validate_executables()` uses `is_file()`, which
   always returns `False` for `.app` bundles, so games were never marked
   as installed
3. **Launch** — `_launch_exe()` raised `FileNotFoundError` because of
   the same `is_file()` check

## Fix

- `external/filepicker.py` — `.app` dirs display with a file icon on
  macOS, making them selectable
- `modules/callbacks.py` — `_launch_exe()` launches `.app` dirs via the
  `open` command on macOS
- `common/structs.py` — `validate_executables()` accepts `.app` dirs as
  valid in all three code paths

No changes to Linux or Windows behavior.
