### PR TITLE
Sticky highlight the game showing in the More Info popup

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -3212,12 +3212,17 @@ class MainGUI():
                     # Ctrl + Left click = single select
                     game.selected = not game.selected
                 else:
-                    if any(game.selected for game in globals.games.values()):
+# FC: Use selected_games_count to check for selected games
+                    if self.selected_games_count > 1:
                         for game in globals.games.values():
                             game.selected = False
                     else:
-                        # Mark game as selected so highlight sticks below the popup
+# FC: If there's a single game selected then first deselect it
+                        if self.last_selected_game != None:
+                            self.last_selected_game.selected = False
+# FC: Mark the game clicked on as selected
                         game.selected = True
+                        self.last_selected_game = game
                         # Left click = open game info popup
                         utils.push_popup(self.draw_game_info_popup, game, self.show_games_ids[self.current_tab].copy())
         # Left click drag = swap if in manual sort mode

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -2731,11 +2731,17 @@ class MainGUI():
                         if idx == -1:
                             idx = len(carousel_ids) - 1
                         change_id = carousel_ids[idx]
+                        # remove highlight from previous game and highlight the current game
+                        game.selected = False
+                        globals.games[change_id].selected = True
                     if imgui.is_key_pressed(glfw.KEY_RIGHT, repeat=True) or clicked_right:
                         idx += 1
                         if idx == len(carousel_ids):
                             idx = 0
                         change_id = carousel_ids[idx]
+                        # remove highlight from previous game and highlight the current game
+                        game.selected = False
+                        globals.games[change_id].selected = True
             if change_id is not None:
                 utils.push_popup(self.draw_game_info_popup, globals.games[change_id], carousel_ids).uuid = popup_uuid
                 return True
@@ -3210,6 +3216,8 @@ class MainGUI():
                         for game in globals.games.values():
                             game.selected = False
                     else:
+                        # Mark game as selected so highlight sticks below the popup
+                        game.selected = True
                         # Left click = open game info popup
                         utils.push_popup(self.draw_game_info_popup, game, self.show_games_ids[self.current_tab].copy())
         # Left click drag = swap if in manual sort mode


### PR DESCRIPTION
When using the More Info popup's Left/Right buttons, the game currently showing in the popup, will have the 'CTRL-Click' highlight applied. Since it uses the Ctrl-Click select highlight, it will remain 'selected' when the popup is closed. This makes it easier to localize the last-viewed game when the list or view contains many games even when  the game is off-screen when the popup is closed.

In Kanban view, this may act a little differently than expected, since the popup will follow the list order, and the last viewed game may be in a totally different Kanban column than where you started viewing.

I've included a small screen recording to show this in action

[sticky800..webm](https://github.com/user-attachments/assets/a6632439-5512-433e-9965-0e3e00fb575d)
