### PR TITLE
Make Godot a recognizable engine type

### DIFF
--- a/common/parser.py
+++ b/common/parser.py
@@ -293,6 +293,8 @@ def thread(res: bytes) -> ParsedThread | ParserError:
             type = Type.ADRIFT
         elif game_has_prefixes("Flash"):
             type = Type.Flash
+        elif game_has_prefixes("Godot"):
+            type = Type.Godot
         elif game_has_prefixes("HTML"):
             type = Type.HTML
         elif game_has_prefixes("Java"):

--- a/common/structs.py
+++ b/common/structs.py
@@ -900,6 +900,7 @@ class Settings:
 Type = IntEnumHack("Type", [
     ("ADRIFT",     (2,  {"color": colors.hex_to_rgba_0_1("#2196F3"), "category": Category.Games})),
     ("Flash",      (4,  {"color": colors.hex_to_rgba_0_1("#616161"), "category": Category.Games})),
+    ("Godot",      (31, {"color": colors.hex_to_rgba_0_1("#03A9F4"), "category": Category.Games})),
     ("HTML",       (5,  {"color": colors.hex_to_rgba_0_1("#689F38"), "category": Category.Games})),
     ("Java",       (6,  {"color": colors.hex_to_rgba_0_1("#52A6B0"), "category": Category.Games})),
     ("Others",     (9,  {"color": colors.hex_to_rgba_0_1("#8BC34A"), "category": Category.Games})),


### PR DESCRIPTION
[Godot has been added](https://f95zone.to/threads/add-godot-as-an-official-engine-prefix.259478/post-20568292) as an engine type to the filter in the Latest Updates page. 