### PR TITLE
QoL: Add Cmd+W shortcut to close window on macOS

### DIFF
--- a/external/imgui_glfw.py
+++ b/external/imgui_glfw.py
@@ -67,6 +67,8 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
 
         if action == glfw.PRESS:
             io.keys_down[key] = True
+            if key == glfw.KEY_W and (mods & glfw.MOD_SUPER):
+                self.close_callback(window)
         elif action == glfw.RELEASE:
             io.keys_down[key] = False
 

--- a/external/imgui_glfw.py
+++ b/external/imgui_glfw.py
@@ -68,7 +68,7 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
         if action == glfw.PRESS:
             io.keys_down[key] = True
             if key == glfw.KEY_W and (mods & glfw.MOD_SUPER):
-                self.close_callback(window)
+                glfw.set_window_should_close(window, True)
         elif action == glfw.RELEASE:
             io.keys_down[key] = False
 

--- a/external/imgui_glfw.py
+++ b/external/imgui_glfw.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import
 
+import sys
+
 import glfw
 import imgui
 
@@ -67,7 +69,7 @@ class GlfwRenderer(ProgrammablePipelineRenderer):
 
         if action == glfw.PRESS:
             io.keys_down[key] = True
-            if key == glfw.KEY_W and (mods & glfw.MOD_SUPER):
+            if sys.platform.startswith("darwin") and key == glfw.KEY_W and (mods & glfw.MOD_SUPER):
                 glfw.set_window_should_close(window, True)
         elif action == glfw.RELEASE:
             io.keys_down[key] = False


### PR DESCRIPTION
## Summary

- Adds `Cmd+W` as a keyboard shortcut to close the window on macOS, consistent with standard macOS app behavior
- Gated to `sys.platform.startswith("darwin")` so it has no effect on Windows/Linux (where `MOD_SUPER` is the Windows/Super key and `Win+W` is not a standard close shortcut)

## Test plan

- [X] On macOS: open the app, press `Cmd+W` — window should close
- [ ] On Windows/Linux: verify `Win+W` does nothing