### PR TITLE
Fix webview blank page on macOS: create QtWebEngineProcess qt.conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,15 @@ jobs:
           mkdir ./dist/
           mv ./build/*.app/ ./dist/
 
+          # Qt looks up its paths via CFBundleGetBundleWithIdentifier, which returns NULL
+          # for flat dylibs (not framework bundles). CFBundleCopyBundleURL(NULL) crashes
+          # in __CFCheckCFInfoPACSignature. Providing qt.conf bypasses the CFBundle lookup.
+          mkdir $(echo ./dist/*.app)/Contents/Helpers/QtWebEngineProcess.app/Contents/Resources/
+          cat << EOF > $(echo ./dist/*.app)/Contents/Helpers/QtWebEngineProcess.app/Contents/Resources/qt.conf
+          [Paths]
+          Prefix = ../../../Resources/lib/PyQt6/Qt6
+          EOF
+
       - name: "Resolve symlinks (Linux, macOS)"
         if: "runner.os != 'Windows'"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 - Fix updating on Windows when the app closes faster than Powershell starts (by @WillyJL)
 - Detect unsupported configurations with app data and app install locations overlapping (by @WillyJL)
 - Fix horizontal scrolling in more info popup (by @WillyJL)
+- Fix webview blank page on macOS (#269 by @cantunborn)
 
 ### Removed:
 - Nothing
 
 ### Known Issues:
-- MacOS webview in frozen binaries remains blank, run from source instead
 - The new notification-daemon process on Linux can sometimes get stuck spinning and cause the app to crash

--- a/modules/patches.py
+++ b/modules/patches.py
@@ -30,6 +30,14 @@ def apply():
             process = meta.self_path.parent / "Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess"
             if process.is_file():
                 os.environ["QTWEBENGINEPROCESS_PATH"] = str(process)
+                # Qt looks up its paths via CFBundleGetBundleWithIdentifier, which returns NULL
+                # for flat dylibs (not framework bundles). CFBundleCopyBundleURL(NULL) crashes
+                # in __CFCheckCFInfoPACSignature. Providing qt.conf bypasses the CFBundle lookup.
+                qtconf_dir = process.parent.parent / "Resources"
+                qtconf_path = qtconf_dir / "qt.conf"
+                if not qtconf_path.exists():
+                    qtconf_dir.mkdir(parents=True, exist_ok=True)
+                    qtconf_path.write_text("[Paths]\nPrefix = ../../../Resources/lib/PyQt6/Qt6\n")
 
     # Pillow image loading fixes
     import pillow_avif

--- a/modules/patches.py
+++ b/modules/patches.py
@@ -30,14 +30,6 @@ def apply():
             process = meta.self_path.parent / "Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess"
             if process.is_file():
                 os.environ["QTWEBENGINEPROCESS_PATH"] = str(process)
-                # Qt looks up its paths via CFBundleGetBundleWithIdentifier, which returns NULL
-                # for flat dylibs (not framework bundles). CFBundleCopyBundleURL(NULL) crashes
-                # in __CFCheckCFInfoPACSignature. Providing qt.conf bypasses the CFBundle lookup.
-                qtconf_dir = process.parent.parent / "Resources"
-                qtconf_path = qtconf_dir / "qt.conf"
-                if not qtconf_path.exists():
-                    qtconf_dir.mkdir(parents=True, exist_ok=True)
-                    qtconf_path.write_text("[Paths]\nPrefix = ../../../Resources/lib/PyQt6/Qt6\n")
 
     # Pillow image loading fixes
     import pillow_avif


### PR DESCRIPTION
QtWebEngineProcess crashes on startup (SIGSEGV at 0x8) because Qt's QLibraryInfoPrivate::paths() calls CFBundleGetBundleWithIdentifier to locate qt.conf, which returns NULL for flat dylibs (not .framework bundles). CFBundleCopyBundleURL(NULL) then segfaults in __CFCheckCFInfoPACSignature, killing the renderer before any page content can be drawn — only the title (received before rendering) was visible.

Fix: on first launch, write a qt.conf into
QtWebEngineProcess.app/Contents/Resources/ pointing its Prefix at the main bundle's Qt6 directory. Qt reads this before falling back to CFBundle, bypassing the crash entirely.

Fixes https://github.com/WillyJL/F95Checker/issues/181.