### PR TITLE
Fix game popup horizontal scroll

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -2137,6 +2137,7 @@ class MainGUI():
 
     def draw_game_info_popup(self, game: Game, carousel_ids: list = None, popup_uuid: str = ""):
         def popup_content():
+            imgui.set_scroll_x(0.0)
             # Image
             image = game.image
             avail = imgui.get_content_region_available()


### PR DESCRIPTION
Game popup scrolls horizontally, even though content doesn't overflow. Added fix for that. Bug and fix checked on macOS. 